### PR TITLE
Fix #2: Correct name of ENV variable required on the assertion error message

### DIFF
--- a/src/Binance.jl
+++ b/src/Binance.jl
@@ -18,7 +18,7 @@ function apiKS()
     apiKey = get(ENV, "BINANCE_APIKEY", "")
     apiSecret = get(ENV, "BINANCE_SECRET", "")
 
-    @assert apiKey != "" || apiSecret != "" "BINANCE_APIKEY/BINANCE_APISECRET should be present in the environment dictionary ENV"
+    @assert apiKey != "" || apiSecret != "" "BINANCE_APIKEY/BINANCE_SECRET should be present in the environment dictionary ENV"
 
     apiKey, apiSecret
 end


### PR DESCRIPTION
Correct name of ENV variable on the assertion error message